### PR TITLE
Increase default number of dice rolls from 4 to 6

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,9 +129,9 @@
 		<div class="btn-group-lg" role="group" aria-label="...">
 		<button id="button-dice-2" type="button" class="btn btn-default dice_button">2</button>
 		<button id="button-dice-3" type="button" class="btn btn-default dice_button">3</button>
-		<button id="button-dice-4" type="button" class="btn btn-default dice_button active">4</button>
+		<button id="button-dice-4" type="button" class="btn btn-default dice_button">4</button>
 		<button id="button-dice-5" type="button" class="btn btn-default dice_button">5</button>
-		<button id="button-dice-6" type="button" class="btn btn-default dice_button">6</button>
+		<button id="button-dice-6" type="button" class="btn btn-default dice_button active">6</button>
 		<button id="button-dice-7" type="button" class="btn btn-default dice_button">7</button>
 		<button id="button-dice-8" type="button" class="btn btn-default dice_button">8</button>
 		</div>


### PR DESCRIPTION
Diceware provides about 12.92 bits of entropy per word. Best practice for
passwords is to reach at least 70 bits of entropy to stay outside of successful
clustered offline password cracking.

    4 Diceware words: ~51.6 bits
    5 Diceware words: ~64.6 bits
    6 Diceware words: ~77.5 bits