### PR TITLE
When building Docker image, install dependencies before calling webpack.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir /tmp/diceware
 COPY . /tmp/diceware/
 WORKDIR /tmp/diceware
 
-RUN npm run build
+RUN npm install && npm run build
 
 FROM nginx:1.25-bullseye
 


### PR DESCRIPTION
Fixes the Docker build to be compatible with the change from #59 .